### PR TITLE
add scripts for connecting all steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,25 @@ Variant Gene Info
 ```
 
 
+### `run_call_chets.sh`: A wrapper that combines all the above 
+That script combines several tools to a pipeline for CompHet calling. In particular, for a given chromosome:
+1. Calls BCFtools (alternative to `get_non_ref_sites`) to extract non-ref genotypes for a phased BCF. 
+2. Then uses `prepare_genemap.py` to prepare gene-variant maps according to each consequence (e.g. pLoF + damaging_missense).
+3. Based on that, it calls `call_chets` to detect CompHet events from the output of step-1.
+4. Finally, it runs `encode_vcf` to create a VCF based on each consequence and type of effects, e.g. additive or recessive.
+
+As a last step, we could combine any chrom-based files to one genome-wide by running
+```
+for consq in pLoF pLoF_damaging damaging_missense synonymous; do
+    for mode in additive recessive; do
+        echo FIXTHIS.chr{1..22}.$mode.$consq.vcf.gz| tr ' ' '\n' > files.txt 
+        bcftools concat -f files.txt -Oz -o FIXTHIS.chrALL.$mode.$consq.vcf.gz
+    done
+done
+```
+
+
+
 
 
 

--- a/prepare_genemap.py
+++ b/prepare_genemap.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+# coding: utf-8
+"""
+A script converts the gene annotation file to a variant-gene index to use in `call_hets`, based on a specific consequence.
+
+Run as
+`python prepare_genemap.py -a brava_GNH_44k_chr22.txt -c pLoF X Y -o gene_map.pLoF_X_Y.txt`
+
+###################
+GK - Sept 1st, 2023
+
+TODO: what if one variant is assigned to several genes?
+"""
+import pandas as pd
+import argparse
+
+parser = argparse.ArgumentParser(description="Convert the gene annotation file to a variant-gene index, based on a specific consequence.")
+parser.add_argument("--anno", "-a", help="file with gene annotation (as in BRaVa/SAIGE)", required=True, type=str)
+parser.add_argument("--consq", "-c", nargs='+', help="class of consequence to process (list if many)", required=True, type=str)
+parser.add_argument("--out", "-o", help="filename for the output", required=True, type=str)
+args = parser.parse_args()
+
+print("Will process the set of", args.consq)
+gene_data_all = {} # this dict will contain one DF per gene, for all genes in the analysis
+r=0
+with open( args.anno, 'r') as fin:
+    for line in fin:
+        tokens = line.split()
+        if r%2==0 :
+            gene_set_vars = tokens[2:]
+        else:
+            gene_set_anns = tokens[2:]
+            gene_data_all[ tokens[0] ] = pd.DataFrame( {"SNPID":gene_set_vars, "Class": gene_set_anns } ) #.set_index('SNPID')
+
+        r += 1
+
+print( f"Variant annotation loaded for {len(gene_data_all)} genes." )
+
+snps_processed = 0
+gens_processed = 0
+weird = 0
+with open(args.out, 'w') as fout:
+    for gene in gene_data_all:
+        tmp_df = gene_data_all[ gene ].query( 'Class in @args.consq' )
+        if len(tmp_df)>0:
+            # print one line per variant
+            for x in tmp_df.iterrows():
+                fout.write( f'{x[1].SNPID} {gene}\n')
+            snps_processed += len(tmp_df)
+            gens_processed += 1
+        else:
+            weird += 1
+            # print( f"No {args.consq} snps found in {gene}.")
+
+if weird>0: print(f"Genes without any variants in {args.consq}:{weird}.")
+
+print( f"All done, {snps_processed} variants were processed across {gens_processed} genes." )

--- a/run_call_chets.sh
+++ b/run_call_chets.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# this is a wrapper that combines several tools towards a pipeline for CompHet calling.
+# input: phased genotypes, annotations in BRaVa/SAIGE format
+# output: VCFs based on different consequences, for either additive or recessive effects
+
+# GK: Sept 11th, 2023
+
+#TODO: add feature for filtering based on PP
+
+cpp_dir="/software/team281/gk18/call_chets/"
+module load common-apps/bcftools/1.18
+
+if [[ -z $1 ]]; then
+    CHR=$LSB_JOBINDEX
+else
+    CHR=$1
+fi
+echo "Will create VCFs with biallelic encodings for chr-$CHR."
+
+work_dir="/FIXTHIS/phasing"
+out_dir="$work_dir/recessive_encoding/vcf_ready"
+tmp_dir="$work_dir/recessive_encoding/sandbox"
+BCF="$work_dir/phased_genotypes_rare/GNH_39k.chr$CHR.phased_rare.no100trios.bcf"
+annot="/FIXTHIS/annotations/brava_GNH_44k_chr$CHR.txt"
+genotypes="$tmp_dir/chr$CHR.nonref.txt.gz"
+
+# if [ ! -f $tmp_dir/chr$CHR.phased_maxmaf01.vcf.gz ]; then 
+if [ ! -f $genotypes ]; then 
+    echo "Generating a file with all genotypes..."
+    bcftools query $BCF --list samples > $tmp_dir/samples.txt
+    bcftools view $BCF --max-af 0.01 -Ou | bcftools query -i'GT="alt"' -f'[%SAMPLE %CHROM:%POS:%REF:%ALT %GT\n]' | gzip > $genotypes
+    # bcftools view --max-af 0.01 $BCF -Oz -o $tmp_dir/chr$CHR.phased_maxmaf01.vcf.g
+    # $cpp_dir/get_non_ref_sites $tmp_dir/chr$CHR.phased_maxmaf01.vcf.gz $genotypes
+fi
+
+for consq in pLoF damaging_missense synonymous; do
+    python prepare_genemap.py -a $annot -c $consq -o $tmp_dir/gene_map.chr$CHR.$consq.txt
+    $cpp_dir/call_chets -g $genotypes -m $tmp_dir/gene_map.chr$CHR.$consq.txt > $tmp_dir/chr$CHR.gen_all.$consq.txt
+    for bial in cis chet hom; do
+        # this is just a progress message
+        grep $bial $tmp_dir/chr$CHR.gen_all.$consq.txt > $tmp_dir/chr$CHR.$bial.$consq.txt
+        tmp=$(wc -l $tmp_dir/chr$CHR.$bial.$consq.txt | cut -d' ' -f1)
+        echo "$bial-$consq events found: $tmp"
+    done
+    $cpp_dir/encode_vcf -i $tmp_dir/chr$CHR.gen_all.$consq.txt -s $tmp_dir/samples.txt -m additive  | bgzip > $out_dir/chr$CHR.additive.$consq.vcf.gz
+    $cpp_dir/encode_vcf -i $tmp_dir/chr$CHR.gen_all.$consq.txt -s $tmp_dir/samples.txt -m recessive | bgzip > $out_dir/chr$CHR.recessive.$consq.vcf.gz
+done
+
+# repeat for pLoF & damaging_missense
+consq="pLoF_damaging"
+python prepare_genemap -a $annot -c pLoF damaging_missense -o $tmp_dir/gene_map.chr$CHR.$consq.txt
+$cpp_dir/call_chets -g $genotypes -m $tmp_dir/gene_map.chr$CHR.$consq.txt > $tmp_dir/chr$CHR.gen_all.$consq.txt
+$cpp_dir/encode_vcf -i $tmp_dir/chr$CHR.gen_all.$consq.txt -s $tmp_dir/samples.txt -m additive  | bgzip > $out_dir/chr$CHR.additive.$consq.vcf.gz
+$cpp_dir/encode_vcf -i $tmp_dir/chr$CHR.gen_all.$consq.txt -s $tmp_dir/samples.txt -m recessive | bgzip > $out_dir/chr$CHR.recessive.$consq.vcf.gz
+    
+# rm $out_dir/chr$CHR.gen_all.*.txt


### PR DESCRIPTION
Here are the two scripts I mentioned:
1. one in python that simply "transposes" the gene-variant annotations we got for Brava/Saige, so that we have a new, consequence-based, index for `call_chets`
2. a bash script that brings all together for. a given chromosome. 

I'm keeping these on another [repo of mine](https://github.com/giorkala/GNH_BRaVa_dev_misc/tree/main/recessive_encoding), so feel free to change anything here.